### PR TITLE
Add image path and description to user type lookups

### DIFF
--- a/Domain/Entities/UserType.cs
+++ b/Domain/Entities/UserType.cs
@@ -1,11 +1,11 @@
-﻿using System.Numerics;
-
-namespace Domain.Entities;
+﻿namespace Domain.Entities;
 
 public class UserType
 {
     public long Id { get; set; }
     public string Name { get; set; }
+    public string ImagePath { get; set; }
+    public string Description { get; set; }
 
     public ICollection<User> Users { get; set; }
 }

--- a/PetSocialAPI/Controllers/LookupController.cs
+++ b/PetSocialAPI/Controllers/LookupController.cs
@@ -51,7 +51,7 @@ public class LookupController : ControllerBase
     public async Task<IActionResult> GetUserTypes()
     {
         var userTypes = await _db.UserTypes
-            .Select(c => new { c.Id, c.Name })
+            .Select(c => new { c.Id, c.Name, c.ImagePath, c.Description })
             .ToListAsync();
 
         return Ok(ApiResponse<object>.Success(userTypes));


### PR DESCRIPTION
## Summary
- add `ImagePath` and `Description` fields to `UserType`
- include those fields when returning user types from lookup API

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6895d8d7daf8832b81c39d1a26307019