### PR TITLE
Include user profile and pet status in login response

### DIFF
--- a/Application/Common/Models/TokenResult.cs
+++ b/Application/Common/Models/TokenResult.cs
@@ -9,4 +9,7 @@ namespace Application.Common.Models;
 public class TokenResult
 {
     public string Token { get; set; }
+    public bool IsPetRegistered { get; set; }
+    public bool IsProfileUpdate { get; set; }
+    public string? UserName { get; set; }
 }


### PR DESCRIPTION
## Summary
- Extend `TokenResult` with fields for pet registration, profile completion, and user name
- Enhance `LoginCommandHandler` to populate new response fields based on user profile and pet data

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899803ef584832b8973e883c6048a8e