### PR TITLE
Enhance login response with user and pet info

### DIFF
--- a/Application/Common/Models/TokenResult.cs
+++ b/Application/Common/Models/TokenResult.cs
@@ -9,4 +9,7 @@ namespace Application.Common.Models;
 public class TokenResult
 {
     public string Token { get; set; }
+    public bool IsPetRegistered { get; set; }
+    public bool IsProfileUpdated { get; set; }
+    public string UserName { get; set; }
 }

--- a/Application/Users/Commands/RegisterUserCommandHandler.cs
+++ b/Application/Users/Commands/RegisterUserCommandHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Persistence;
+using System.Linq;
 
 namespace Application.Users.Commands;
 
@@ -113,7 +114,13 @@ public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand, A
 
             await transaction.CommitAsync(cancellationToken);
 
-            var tokenResult = new TokenResult { Token = generateTokenTask.Result };
+            var tokenResult = new TokenResult
+            {
+                Token = generateTokenTask.Result,
+                IsPetRegistered = false,
+                IsProfileUpdated = false,
+                UserName = request.Name
+            };
 
             return ApiResponse<TokenResult>.Success(tokenResult, "User registered successfully!", 201);
 


### PR DESCRIPTION
## Summary
- include pet and profile flags plus user name in token result
- populate login and external-login responses with pet registration status
- initialize new fields after user registration

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899829a8704832b846cd4ca13748a1c