### PR TITLE
Add user and pet profile retrieval endpoints

### DIFF
--- a/Application/Pets/Queries/GetPetProfileQuery.cs
+++ b/Application/Pets/Queries/GetPetProfileQuery.cs
@@ -1,0 +1,132 @@
+using Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+
+namespace Application.Pets.Queries;
+
+public class GetPetProfileQuery : IRequest<ApiResponse<PetProfileResult>>
+{
+    public string IdentityId { get; set; }
+    public long? PetId { get; set; }
+}
+
+public class PetProfileResult
+{
+    public PetDetailDto Pet { get; set; }
+    public List<PetSummaryDto> Pets { get; set; }
+}
+
+public class PetSummaryDto
+{
+    public long Id { get; set; }
+    public string PetName { get; set; }
+}
+
+public class PetDetailDto
+{
+    public long Id { get; set; }
+    public long PetTypeId { get; set; }
+    public string? PetTypeName { get; set; }
+    public string? CustomPetTypeName { get; set; }
+    public string PetName { get; set; }
+    public string PetFoundAt { get; set; }
+    public string ImagePath { get; set; }
+    public string? Gender { get; set; }
+    public DateTime? DOB { get; set; }
+    public long? PetBreedId { get; set; }
+    public string? PetBreedName { get; set; }
+    public string? CustomPetBreed { get; set; }
+    public bool IsMixedBreed { get; set; }
+    public string? FirstBreed { get; set; }
+    public string? SecondBreed { get; set; }
+    public long? PetColorId { get; set; }
+    public List<MixColorDetailDto> MixColors { get; set; } = new();
+    public string? Food { get; set; }
+    public long? PetFoodId { get; set; }
+    public string? CustomFood { get; set; }
+    public decimal? Weight { get; set; }
+    public string? WeightUnit { get; set; }
+    public string? Character { get; set; }
+}
+
+public class MixColorDetailDto
+{
+    public string Color { get; set; }
+    public decimal Percentage { get; set; }
+}
+
+public class GetPetProfileQueryHandler : IRequestHandler<GetPetProfileQuery, ApiResponse<PetProfileResult>>
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public GetPetProfileQueryHandler(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<ApiResponse<PetProfileResult>> Handle(GetPetProfileQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.IdentityId == request.IdentityId, cancellationToken);
+        if (user == null)
+            return ApiResponse<PetProfileResult>.Fail("User not found.", 404);
+
+        var pets = await _dbContext.UserPets
+            .Where(p => p.UserId == user.Id)
+            .Select(p => new PetSummaryDto { Id = p.Id, PetName = p.PetName })
+            .ToListAsync(cancellationToken);
+
+        if (!pets.Any())
+            return ApiResponse<PetProfileResult>.Fail("No pets found.", 404);
+
+        var selectedPetId = request.PetId ?? pets.First().Id;
+
+        var pet = await _dbContext.UserPets
+            .Include(p => p.PetType)
+            .Include(p => p.PetBreed)
+            .Include(p => p.UserPetColors).ThenInclude(pc => pc.UserPetMixColors)
+            .Include(p => p.UserPetOtherBreeds)
+            .FirstOrDefaultAsync(p => p.Id == selectedPetId && p.UserId == user.Id, cancellationToken);
+
+        if (pet == null)
+            return ApiResponse<PetProfileResult>.Fail("Pet not found.", 404);
+
+        var detail = new PetDetailDto
+        {
+            Id = pet.Id,
+            PetTypeId = pet.PetTypeId,
+            PetTypeName = pet.PetType?.Name,
+            CustomPetTypeName = pet.CustomPetTypeName,
+            PetName = pet.PetName,
+            PetFoundAt = pet.PetFoundAt,
+            ImagePath = pet.ImagePath,
+            Gender = pet.Gender,
+            DOB = pet.DOB,
+            PetBreedId = pet.PetBreedId,
+            PetBreedName = pet.PetBreed?.Name,
+            CustomPetBreed = pet.CustomPetBreed,
+            Food = pet.Food,
+            PetFoodId = pet.PetFoodId,
+            CustomFood = pet.CustomFood,
+            Weight = pet.Weight,
+            WeightUnit = pet.WeightUnit,
+            Character = pet.Character,
+            IsMixedBreed = pet.UserPetOtherBreeds != null && pet.UserPetOtherBreeds.Any(),
+            FirstBreed = pet.UserPetOtherBreeds?.FirstOrDefault()?.FirstBreed,
+            SecondBreed = pet.UserPetOtherBreeds?.FirstOrDefault()?.SecondBreed,
+            PetColorId = pet.UserPetColors?.FirstOrDefault()?.PetColorId,
+            MixColors = pet.UserPetColors?.SelectMany(c => c.UserPetMixColors)
+                .Select(mc => new MixColorDetailDto { Color = mc.Color, Percentage = mc.Percentage })
+                .ToList() ?? new List<MixColorDetailDto>()
+        };
+
+        var result = new PetProfileResult
+        {
+            Pet = detail,
+            Pets = pets
+        };
+
+        return ApiResponse<PetProfileResult>.Success(result);
+    }
+}
+

--- a/Application/Users/Queries/GetUserProfileQuery.cs
+++ b/Application/Users/Queries/GetUserProfileQuery.cs
@@ -1,0 +1,99 @@
+using Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+
+namespace Application.Users.Queries;
+
+public class GetUserProfileQuery : IRequest<ApiResponse<UserProfileDto>>
+{
+    public string IdentityId { get; set; }
+}
+
+public class UserProfileDto
+{
+    public long Id { get; set; }
+    public string Name { get; set; }
+    public string CountryCode { get; set; }
+    public string PhoneNumber { get; set; }
+    public string? Email { get; set; }
+    public long UserTypeId { get; set; }
+    public string? UserTypeName { get; set; }
+    public PetOwnerProfileDto? OwnerProfile { get; set; }
+    public PetBusinessProfileDto? BusinessProfile { get; set; }
+    public ContentCreatorProfileDto? CreatorProfile { get; set; }
+}
+
+public class PetOwnerProfileDto
+{
+    public string Gender { get; set; }
+    public DateTime? DOB { get; set; }
+    public string ImagePath { get; set; }
+}
+
+public class PetBusinessProfileDto
+{
+    public string BusinessName { get; set; }
+    public string Address { get; set; }
+    public string WebsiteUrl { get; set; }
+}
+
+public class ContentCreatorProfileDto
+{
+    public string ChannelName { get; set; }
+    public int FollowersCount { get; set; }
+}
+
+public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, ApiResponse<UserProfileDto>>
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public GetUserProfileQueryHandler(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<ApiResponse<UserProfileDto>> Handle(GetUserProfileQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users
+            .Include(u => u.UserType)
+            .Include(u => u.PetOwnerProfile)
+            .Include(u => u.PetBusinessProfile)
+            .Include(u => u.ContentCreatorProfile)
+            .FirstOrDefaultAsync(u => u.IdentityId == request.IdentityId, cancellationToken);
+
+        if (user == null)
+            return ApiResponse<UserProfileDto>.Fail("User not found.", 404);
+
+        var dto = new UserProfileDto
+        {
+            Id = user.Id,
+            Name = user.Name,
+            CountryCode = user.CountryCode,
+            PhoneNumber = user.PhoneNumber,
+            Email = user.Email,
+            UserTypeId = user.UserTypeId,
+            UserTypeName = user.UserType?.Name,
+            OwnerProfile = user.PetOwnerProfile == null ? null : new PetOwnerProfileDto
+            {
+                Gender = user.PetOwnerProfile.Gender,
+                DOB = user.PetOwnerProfile.DOB,
+                ImagePath = user.PetOwnerProfile.ImagePath
+            },
+            BusinessProfile = user.PetBusinessProfile == null ? null : new PetBusinessProfileDto
+            {
+                BusinessName = user.PetBusinessProfile.BusinessName,
+                Address = user.PetBusinessProfile.Address,
+                WebsiteUrl = user.PetBusinessProfile.WebsiteUrl
+            },
+            CreatorProfile = user.ContentCreatorProfile == null ? null : new ContentCreatorProfileDto
+            {
+                ChannelName = user.ContentCreatorProfile.ChannelName,
+                FollowersCount = user.ContentCreatorProfile.FollowersCount
+            }
+        };
+
+        return ApiResponse<UserProfileDto>.Success(dto);
+    }
+}
+

--- a/PetSocialAPI/Controllers/ProfileController.cs
+++ b/PetSocialAPI/Controllers/ProfileController.cs
@@ -1,0 +1,49 @@
+using Application.Common.Models;
+using Application.Users.Queries;
+using Application.Pets.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PetSocialAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class ProfileController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public ProfileController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    [HttpGet("user")]
+    public async Task<IActionResult> GetUserProfile()
+    {
+        var identityId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+
+        if (string.IsNullOrEmpty(identityId))
+            return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
+
+        var result = await _mediator.Send(new GetUserProfileQuery { IdentityId = identityId });
+        return StatusCode(result.StatusCode, result);
+    }
+
+    [HttpGet("pet")]
+    public async Task<IActionResult> GetPetProfile([FromQuery] long? petId)
+    {
+        var identityId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+
+        if (string.IsNullOrEmpty(identityId))
+            return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
+
+        var query = new GetPetProfileQuery { IdentityId = identityId, PetId = petId };
+        var result = await _mediator.Send(query);
+        return StatusCode(result.StatusCode, result);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement GetUserProfileQuery and handler to return user profile details
- implement GetPetProfileQuery and handler to fetch pet details plus user's pets list
- add ProfileController with endpoints for user and pet profile retrieval

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689d5a7297e0832ba49b264f4e956a3f