### PR TITLE
feat: allow users to update profile

### DIFF
--- a/Application/Users/Commands/UpdateUserProfileCommand.cs
+++ b/Application/Users/Commands/UpdateUserProfileCommand.cs
@@ -1,0 +1,14 @@
+using Application.Common.Models;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace Application.Users.Commands;
+
+public class UpdateUserProfileCommand : IRequest<ApiResponse<TokenResult>>
+{
+    public string? IdentityId { get; set; }
+    public string Name { get; set; }
+    public string Gender { get; set; }
+    public string? Bio { get; set; }
+    public IFormFile? Image { get; set; }
+}

--- a/Application/Users/Commands/UpdateUserProfileCommandHandler.cs
+++ b/Application/Users/Commands/UpdateUserProfileCommandHandler.cs
@@ -1,0 +1,86 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+
+namespace Application.Users.Commands;
+
+public class UpdateUserProfileCommandHandler : IRequestHandler<UpdateUserProfileCommand, ApiResponse<TokenResult>>
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly IImageService _imageService;
+
+    public UpdateUserProfileCommandHandler(ApplicationDbContext dbContext, IImageService imageService)
+    {
+        _dbContext = dbContext;
+        _imageService = imageService;
+    }
+
+    public async Task<ApiResponse<TokenResult>> Handle(UpdateUserProfileCommand request, CancellationToken cancellationToken)
+    {
+        string uploadedPublicId = null;
+        using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            var user = await _dbContext.Users
+                .Include(u => u.PetOwnerProfile)
+                .FirstOrDefaultAsync(u => u.IdentityId == request.IdentityId, cancellationToken);
+
+            if (user == null)
+                return ApiResponse<TokenResult>.Fail("User not found.", 404);
+
+            user.Name = request.Name;
+            user.UpdatedAt = DateTime.Now;
+            _dbContext.Users.Update(user);
+
+            var profile = user.PetOwnerProfile;
+            string imageUrl = profile?.ImagePath;
+
+            if (request.Image != null)
+            {
+                var uploadResult = await _imageService.UploadImageAsync(request.Image);
+                imageUrl = uploadResult.Url;
+                uploadedPublicId = uploadResult.PublicId;
+            }
+
+            if (profile == null)
+            {
+                profile = new PetOwnerProfile
+                {
+                    UserId = user.Id,
+                    Gender = request.Gender,
+                    Bio = request.Bio,
+                    ImagePath = imageUrl
+                };
+                await _dbContext.PetOwnerProfiles.AddAsync(profile, cancellationToken);
+            }
+            else
+            {
+                profile.Gender = request.Gender;
+                profile.Bio = request.Bio;
+                profile.ImagePath = imageUrl;
+                profile.UpdatedAt = DateTime.Now;
+                _dbContext.PetOwnerProfiles.Update(profile);
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await tx.CommitAsync(cancellationToken);
+            return ApiResponse<TokenResult>.Success(null, "Profile updated!", 200);
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync(cancellationToken);
+            if (!string.IsNullOrEmpty(uploadedPublicId))
+            {
+                try
+                {
+                    await _imageService.DeleteImageAsync(uploadedPublicId);
+                }
+                catch { }
+            }
+            return ApiResponse<TokenResult>.Fail("Update error: " + ex.Message, 500);
+        }
+    }
+}

--- a/Application/Users/Queries/GetUserProfileQuery.cs
+++ b/Application/Users/Queries/GetUserProfileQuery.cs
@@ -29,6 +29,7 @@ public class PetOwnerProfileDto
     public string Gender { get; set; }
     public DateTime? DOB { get; set; }
     public string ImagePath { get; set; }
+    public string? Bio { get; set; }
 }
 
 public class PetBusinessProfileDto
@@ -78,7 +79,8 @@ public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, A
             {
                 Gender = user.PetOwnerProfile.Gender,
                 DOB = user.PetOwnerProfile.DOB,
-                ImagePath = user.PetOwnerProfile.ImagePath
+                ImagePath = user.PetOwnerProfile.ImagePath,
+                Bio = user.PetOwnerProfile.Bio
             },
             BusinessProfile = user.PetBusinessProfile == null ? null : new PetBusinessProfileDto
             {

--- a/Domain/Entities/PetOwnerProfile.cs
+++ b/Domain/Entities/PetOwnerProfile.cs
@@ -12,6 +12,7 @@ public class PetOwnerProfile
     public string Gender { get; set; }
     public DateTime? DOB { get; set; }
     public string ImagePath { get; set; }
+    public string? Bio { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.Now;
     public DateTime UpdatedAt { get; set; } = DateTime.Now;
 

--- a/Persistence/Migrations/20250724190000_AddBioToPetOwnerProfile.cs
+++ b/Persistence/Migrations/20250724190000_AddBioToPetOwnerProfile.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations;
+
+public partial class AddBioToPetOwnerProfile : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "Bio",
+            table: "PetOwnerProfile",
+            type: "nvarchar(max)",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Bio",
+            table: "PetOwnerProfile");
+    }
+}

--- a/PetSocialAPI/Controllers/ProfileController.cs
+++ b/PetSocialAPI/Controllers/ProfileController.cs
@@ -1,6 +1,7 @@
 using Application.Common.Models;
 using Application.Users.Queries;
 using Application.Pets.Queries;
+using Application.Users.Commands;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -29,6 +30,20 @@ public class ProfileController : ControllerBase
             return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
 
         var result = await _mediator.Send(new GetUserProfileQuery { IdentityId = identityId });
+        return StatusCode(result.StatusCode, result);
+    }
+
+    [HttpPut("user")]
+    public async Task<IActionResult> UpdateUserProfile([FromForm] UpdateUserProfileCommand command)
+    {
+        var identityId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+
+        if (string.IsNullOrEmpty(identityId))
+            return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
+
+        command.IdentityId = identityId;
+        var result = await _mediator.Send(command);
         return StatusCode(result.StatusCode, result);
     }
 


### PR DESCRIPTION
## Summary
- add Bio column to pet owner profile entity and migration
- implement UpdateUserProfile command/handler with image upload and transaction
- expose new bio field via user profile query and controller endpoint

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6e3392ac832b9a66a895d5642bf5