### PR TITLE
Add basic pet story endpoints

### DIFF
--- a/Domain/Entities/PetStory.cs
+++ b/Domain/Entities/PetStory.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+
+namespace Domain.Entities;
+
+public class PetStory
+{
+    public long Id { get; set; }
+    public long PetId { get; set; }
+    public string MediaUrl { get; set; }
+    public string MediaType { get; set; } // "image" or "video"
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime ExpiresAt { get; set; } = DateTime.UtcNow.AddDays(1);
+
+    public ICollection<PetStoryView>? Views { get; set; }
+    public ICollection<PetStoryLike>? Likes { get; set; }
+    public ICollection<PetStoryComment>? Comments { get; set; }
+}

--- a/Domain/Entities/PetStoryComment.cs
+++ b/Domain/Entities/PetStoryComment.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Domain.Entities;
+
+public class PetStoryComment
+{
+    public long Id { get; set; }
+    public long StoryId { get; set; }
+    public long CommenterPetId { get; set; }
+    public string Text { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public PetStory? Story { get; set; }
+}

--- a/Domain/Entities/PetStoryLike.cs
+++ b/Domain/Entities/PetStoryLike.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Domain.Entities;
+
+public class PetStoryLike
+{
+    public long Id { get; set; }
+    public long StoryId { get; set; }
+    public long LikerPetId { get; set; }
+    public DateTime LikedAt { get; set; } = DateTime.UtcNow;
+
+    public PetStory? Story { get; set; }
+}

--- a/Domain/Entities/PetStoryView.cs
+++ b/Domain/Entities/PetStoryView.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Domain.Entities;
+
+public class PetStoryView
+{
+    public long Id { get; set; }
+    public long StoryId { get; set; }
+    public long ViewerPetId { get; set; }
+    public DateTime ViewedAt { get; set; } = DateTime.UtcNow;
+
+    public PetStory? Story { get; set; }
+}

--- a/Persistence/ApplicationDbContext.cs
+++ b/Persistence/ApplicationDbContext.cs
@@ -19,6 +19,10 @@ public class ApplicationDbContext : IdentityDbContext
     public DbSet<UserPetMixColor> UserPetMixColors { get; set; }
     public DbSet<UserPetOtherBreed> UserPetOtherBreeds { get; set; }
     public DbSet<UserOtp> UserOtps { get; set; }
+    public DbSet<PetStory> PetStories { get; set; }
+    public DbSet<PetStoryView> PetStoryViews { get; set; }
+    public DbSet<PetStoryLike> PetStoryLikes { get; set; }
+    public DbSet<PetStoryComment> PetStoryComments { get; set; }
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/Persistence/Configurations/UserConfiguration.cs
+++ b/Persistence/Configurations/UserConfiguration.cs
@@ -10,7 +10,7 @@ public class UserConfiguration : IEntityTypeConfiguration<User>
     {
         builder.HasKey(u => u.Id);
         builder.Property(u => u.Name).HasMaxLength(100).IsRequired();
-        builder.Property(u => u.Phone).HasMaxLength(30);
+        builder.Property(u => u.PhoneNumber).HasMaxLength(30);
         builder.Property(u => u.Email).HasMaxLength(100);
         builder.HasIndex(u => u.IdentityId).IsUnique();
     }

--- a/PetSocialAPI/Controllers/StoriesController.cs
+++ b/PetSocialAPI/Controllers/StoriesController.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+using Domain.Entities;
+using Application.Common.Interfaces;
+
+namespace PetSocialAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class StoriesController : ControllerBase
+{
+    private readonly ApplicationDbContext _db;
+    private readonly IImageService _imageService;
+
+    public StoriesController(ApplicationDbContext db, IImageService imageService)
+    {
+        _db = db;
+        _imageService = imageService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromForm] long petId, [FromForm] IFormFile media, [FromForm] string mediaType)
+    {
+        if (media == null)
+            return BadRequest("Media file is required.");
+        if (string.IsNullOrEmpty(mediaType))
+            return BadRequest("Media type is required.");
+
+        var upload = await _imageService.UploadImageAsync(media);
+        var story = new PetStory
+        {
+            PetId = petId,
+            MediaUrl = upload.Url,
+            MediaType = mediaType
+        };
+        _db.PetStories.Add(story);
+        await _db.SaveChangesAsync();
+        return Ok(new { story.Id, story.MediaUrl });
+    }
+
+    [HttpGet("{petId}")]
+    public async Task<IActionResult> GetStories(long petId)
+    {
+        var now = DateTime.UtcNow;
+        var stories = await _db.PetStories
+            .Where(s => s.PetId == petId && s.ExpiresAt > now)
+            .Include(s => s.Views)
+            .Include(s => s.Likes)
+            .Include(s => s.Comments)
+            .ToListAsync();
+        return Ok(stories);
+    }
+
+    [HttpPost("{id}/view")]
+    public async Task<IActionResult> ViewStory(long id, [FromForm] long viewerPetId)
+    {
+        var exists = await _db.PetStoryViews.AnyAsync(v => v.StoryId == id && v.ViewerPetId == viewerPetId);
+        if (!exists)
+        {
+            _db.PetStoryViews.Add(new PetStoryView { StoryId = id, ViewerPetId = viewerPetId });
+            await _db.SaveChangesAsync();
+        }
+        return Ok();
+    }
+
+    [HttpPost("{id}/like")]
+    public async Task<IActionResult> LikeStory(long id, [FromForm] long likerPetId)
+    {
+        var like = await _db.PetStoryLikes.FirstOrDefaultAsync(l => l.StoryId == id && l.LikerPetId == likerPetId);
+        if (like == null)
+        {
+            _db.PetStoryLikes.Add(new PetStoryLike { StoryId = id, LikerPetId = likerPetId });
+        }
+        else
+        {
+            _db.PetStoryLikes.Remove(like);
+        }
+        await _db.SaveChangesAsync();
+        return Ok();
+    }
+
+    public class CommentRequest
+    {
+        public long CommenterPetId { get; set; }
+        public string Text { get; set; }
+    }
+
+    [HttpPost("{id}/comment")]
+    public async Task<IActionResult> CommentStory(long id, [FromBody] CommentRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text))
+            return BadRequest("Comment text is required.");
+        var comment = new PetStoryComment
+        {
+            StoryId = id,
+            CommenterPetId = request.CommenterPetId,
+            Text = request.Text
+        };
+        _db.PetStoryComments.Add(comment);
+        await _db.SaveChangesAsync();
+        return Ok(comment);
+    }
+
+    [HttpGet("{id}/views")]
+    public async Task<IActionResult> GetViews(long id)
+    {
+        var views = await _db.PetStoryViews.Where(v => v.StoryId == id).ToListAsync();
+        return Ok(views);
+    }
+
+    [HttpGet("{id}/likes")]
+    public async Task<IActionResult> GetLikes(long id)
+    {
+        var likes = await _db.PetStoryLikes.Where(l => l.StoryId == id).ToListAsync();
+        return Ok(likes);
+    }
+
+    [HttpGet("{id}/comments")]
+    public async Task<IActionResult> GetComments(long id)
+    {
+        var comments = await _db.PetStoryComments.Where(c => c.StoryId == id).ToListAsync();
+        return Ok(comments);
+    }
+}

--- a/PetSocialAPI/Program.cs
+++ b/PetSocialAPI/Program.cs
@@ -7,6 +7,7 @@ using PetSocialAPI.Middlewares;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using System.Text.Json.Serialization;
 
 //serilog 
 
@@ -46,8 +47,11 @@ builder.Services.AddAuthentication(options =>
 
 });
 
-
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+    });
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddSwaggerGen();
 bool enableRequestLogging = builder.Configuration.GetValue<bool>("EnableRequestLogging");


### PR DESCRIPTION
## Summary
- add `PetStory` entity with related view, like and comment records
- expose `StoriesController` API to create stories and handle view/like/comment interactions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09062be24832b944b303e72391225