### PR TITLE
Add caption support and story seen tracking

### DIFF
--- a/Domain/Entities/PetStory.cs
+++ b/Domain/Entities/PetStory.cs
@@ -9,6 +9,7 @@ public class PetStory
     public long PetId { get; set; }
     public string MediaUrl { get; set; }
     public string MediaType { get; set; } // "image" or "video"
+    public string? Caption { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime ExpiresAt { get; set; } = DateTime.UtcNow.AddDays(1);
 

--- a/Persistence/ApplicationDbContext.cs
+++ b/Persistence/ApplicationDbContext.cs
@@ -9,8 +9,8 @@ public class ApplicationDbContext : IdentityDbContext
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options): base(options) { }
 
 
-    public DbSet<User> Users { get; set; }
-    public DbSet<UserLogin> UserLogins { get; set; }
+    public new DbSet<User> Users { get; set; }
+    public new DbSet<UserLogin> UserLogins { get; set; }
     public DbSet<UserPet> UserPets { get; set; }
     public DbSet<PetType> PetTypes { get; set; }
     public DbSet<PetBreed> PetBreeds { get; set; }


### PR DESCRIPTION
## Summary
- allow stories to store an optional caption when created
- return grouped stories with seen status per pet
- mark custom DbSets as `new` to fix hidden member warnings

## Testing
- `dotnet build` *(fails: 'TokenResult' does not contain a definition for 'IsProfileUpdated')*

------
https://chatgpt.com/codex/tasks/task_e_68b121b40f60832ba5594d8bece79b35