### PR TITLE
feat: add redoc api documentation

### DIFF
--- a/PetSocialAPI/PetSocialAPI.csproj
+++ b/PetSocialAPI/PetSocialAPI.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PetSocialAPI/Program.cs
+++ b/PetSocialAPI/Program.cs
@@ -107,6 +107,12 @@ if (enableRequestLogging)
 
 
 app.UseSwagger();
+app.UseReDoc(options =>
+{
+    options.DocumentTitle = "PetSocial API Documentation";
+    options.SpecUrl("/swagger/v1/swagger.json");
+    options.RoutePrefix = "docs";
+});
 app.UseSwaggerUI();
 app.UseCors("AllowDevClient");
 


### PR DESCRIPTION
## Summary
- add Swashbuckle ReDoc package
- expose ReDoc at `/docs`

## Testing
- `dotnet build PetSocialAPI/PetSocialAPI.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b99dd82c68832baeb1bf7d7b25cfa6