### PR TITLE
Standardize API responses

### DIFF
--- a/PetSocialAPI/Controllers/DevOpsController.cs
+++ b/PetSocialAPI/Controllers/DevOpsController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Application.Common.Models;
 
 namespace PetSocialAPI.Controllers;
 
@@ -14,7 +15,7 @@ public class DevOpsController(RoleManager<IdentityRole> roleManager, UserManager
     public async Task<IActionResult> SeedRoles([FromHeader(Name = "X-Admin-Secret")] string secret)
     {
         if (secret != "chotulaal@1234")
-            return Unauthorized();
+            return StatusCode(401, ApiResponse<string>.Fail("Unauthorized", 401));
 
         string[] roles = { "Admin", "User" };
         List<string> created = new();
@@ -26,13 +27,13 @@ public class DevOpsController(RoleManager<IdentityRole> roleManager, UserManager
                 if (res.Succeeded) created.Add(role);
             }
         }
-        return Ok(new { created });
+        return StatusCode(200, ApiResponse<object>.Success(new { created }));
     }
     [HttpPost("seed-admin")]
     public async Task<IActionResult> SeedAdmin([FromHeader(Name = "X-Admin-Secret")] string secret)
     {
         if (secret != "chotulaal@1234")
-            return Unauthorized();
+            return StatusCode(401, ApiResponse<string>.Fail("Unauthorized", 401));
 
         var identityUser = new IdentityUser
         {
@@ -42,24 +43,13 @@ public class DevOpsController(RoleManager<IdentityRole> roleManager, UserManager
 
         var result = await _userManager.CreateAsync(identityUser, "inos@1234");
         if (!result.Succeeded)
-            return BadRequest(new
-            {
-                status = false,
-                statusCode = 400,
-                message = "Registration failed: " + string.Join(", ", result.Errors.Select(e => e.Description)),
-                data = (object)null
-            });
+            return StatusCode(400, ApiResponse<string>.Fail(
+                "Registration failed: " + string.Join(", ", result.Errors.Select(e => e.Description)), 400));
         var roleResult = await _userManager.AddToRoleAsync(identityUser, "Admin");
         if (!roleResult.Succeeded)
-            return BadRequest(new
-            {
-                status = false,
-                statusCode = 400,
-                message = "Failed to assign role: " + string.Join(", ", roleResult.Errors.Select(e => e.Description)),
-                data = (object)null
-            });
+            return StatusCode(400, ApiResponse<string>.Fail(
+                "Failed to assign role: " + string.Join(", ", roleResult.Errors.Select(e => e.Description)), 400));
 
-
-        return Ok("Admin Created");
+        return StatusCode(200, ApiResponse<string>.Success("Admin Created"));
     }
 }

--- a/PetSocialAPI/Controllers/DonationsController.cs
+++ b/PetSocialAPI/Controllers/DonationsController.cs
@@ -3,6 +3,7 @@ using Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Persistence;
+using Application.Common.Models;
 
 namespace PetSocialAPI.Controllers;
 
@@ -28,7 +29,7 @@ public class DonationsController : ControllerBase
     public async Task<IActionResult> Donate([FromBody] DonationRequest request)
     {
         if (request.Amount <= 0)
-            return BadRequest("Amount must be greater than zero.");
+            return StatusCode(400, ApiResponse<string>.Fail("Amount must be greater than zero.", 400));
 
         var donation = new PetDonation
         {
@@ -38,6 +39,6 @@ public class DonationsController : ControllerBase
 
         _db.PetDonations.Add(donation);
         await _db.SaveChangesAsync();
-        return Ok(donation);
+        return StatusCode(200, ApiResponse<PetDonation>.Success(donation));
     }
 }

--- a/PetSocialAPI/Controllers/LookupController.cs
+++ b/PetSocialAPI/Controllers/LookupController.cs
@@ -20,7 +20,7 @@ public class LookupController : ControllerBase
             .Select(t => new { t.Id, t.Name, t.ImagePath })
             .ToListAsync();
 
-        return Ok(ApiResponse<object>.Success(types));
+        return StatusCode(200, ApiResponse<object>.Success(types));
     }
 
     [HttpGet("breeds")]
@@ -32,7 +32,7 @@ public class LookupController : ControllerBase
             .Select(b => new { b.Id, b.Name })
             .ToListAsync();
 
-        return Ok(ApiResponse<object>.Success(breeds));
+        return StatusCode(200, ApiResponse<object>.Success(breeds));
     }
 
     [HttpGet("colors")]
@@ -44,7 +44,7 @@ public class LookupController : ControllerBase
             .Select(c => new { c.Id, c.Name })
             .ToListAsync();
 
-        return Ok(ApiResponse<object>.Success(colors));
+        return StatusCode(200, ApiResponse<object>.Success(colors));
     }
 
     [HttpGet("usertypes")]
@@ -54,7 +54,7 @@ public class LookupController : ControllerBase
             .Select(c => new { c.Id, c.Name, c.ImagePath, c.Description })
             .ToListAsync();
 
-        return Ok(ApiResponse<object>.Success(userTypes));
+        return StatusCode(200, ApiResponse<object>.Success(userTypes));
     }
 
     [HttpGet("food")]
@@ -65,6 +65,6 @@ public class LookupController : ControllerBase
             .Select(c => new { c.Id, c.Name })
             .ToListAsync();
 
-        return Ok(ApiResponse<object>.Success(foods));
+        return StatusCode(200, ApiResponse<object>.Success(foods));
     }
 }

--- a/PetSocialAPI/Controllers/WeatherForecastController.cs
+++ b/PetSocialAPI/Controllers/WeatherForecastController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Application.Common.Models;
 
 namespace PetSocialAPI.Controllers
 {
@@ -19,15 +20,16 @@ namespace PetSocialAPI.Controllers
         }
 
         [HttpGet(Name = "GetWeatherForecast")]
-        public IEnumerable<WeatherForecast> Get()
+        public IActionResult Get()
         {
-            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            var forecasts = Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
                 TemperatureC = Random.Shared.Next(-20, 55),
                 Summary = Summaries[Random.Shared.Next(Summaries.Length)]
-            })
-            .ToArray();
+            }).ToArray();
+
+            return StatusCode(200, ApiResponse<IEnumerable<WeatherForecast>>.Success(forecasts));
         }
     }
 }


### PR DESCRIPTION
## Summary
- unify GET and POST API responses across controllers using ApiResponse
- ensure stories, lookups, donations, devops, and weather endpoints return status, code, and data

## Testing
- `dotnet build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba904d0c18832b9cb401c07a8982f6