### PR TITLE
Add pet business profile registration and management

### DIFF
--- a/Application/Businesses/Commands/RegisterPetBusinessCommand.cs
+++ b/Application/Businesses/Commands/RegisterPetBusinessCommand.cs
@@ -1,0 +1,22 @@
+using Application.Common.Models;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace Application.Businesses.Commands;
+
+public class RegisterPetBusinessCommand : IRequest<ApiResponse<long>>
+{
+    public string IdentityId { get; set; }
+    public string BusinessName { get; set; }
+    public string? OwnerName { get; set; }
+    public DateTime? BusinessStartDate { get; set; }
+    public string Address { get; set; }
+    public string PhoneNumber { get; set; }
+    public string Email { get; set; }
+    public string EINorSSN { get; set; }
+    public int? NumberOfEmployees { get; set; }
+    public string? BusinessType { get; set; }
+    public string? GoogleRatingLink { get; set; }
+    public IFormFile? BannerImage { get; set; }
+    public IFormFile? ProfileImage { get; set; }
+}

--- a/Application/Businesses/Commands/RegisterPetBusinessCommandHandler.cs
+++ b/Application/Businesses/Commands/RegisterPetBusinessCommandHandler.cs
@@ -1,0 +1,99 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+
+namespace Application.Businesses.Commands;
+
+public class RegisterPetBusinessCommandHandler : IRequestHandler<RegisterPetBusinessCommand, ApiResponse<long>>
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly IImageService _imageService;
+    private readonly IGoogleRatingService _googleRatingService;
+
+    public RegisterPetBusinessCommandHandler(ApplicationDbContext dbContext, IImageService imageService, IGoogleRatingService googleRatingService)
+    {
+        _dbContext = dbContext;
+        _imageService = imageService;
+        _googleRatingService = googleRatingService;
+    }
+
+    public async Task<ApiResponse<long>> Handle(RegisterPetBusinessCommand request, CancellationToken cancellationToken)
+    {
+        string? bannerPublicId = null;
+        string? profilePublicId = null;
+        using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            var user = await _dbContext.Users
+                .Where(u => u.IdentityId == request.IdentityId)
+                .Select(u => new { u.Id })
+                .FirstOrDefaultAsync(cancellationToken);
+            if (user == null)
+                return ApiResponse<long>.Fail("User not found.", 404);
+
+            var existing = await _dbContext.PetBusinessProfiles
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == user.Id, cancellationToken);
+            if (existing != null)
+                return ApiResponse<long>.Fail("Business profile already exists.", 409);
+
+            string? bannerUrl = null;
+            if (request.BannerImage != null)
+            {
+                var upload = await _imageService.UploadImageAsync(request.BannerImage);
+                bannerUrl = upload.Url;
+                bannerPublicId = upload.PublicId;
+            }
+
+            string? profileUrl = null;
+            if (request.ProfileImage != null)
+            {
+                var upload = await _imageService.UploadImageAsync(request.ProfileImage);
+                profileUrl = upload.Url;
+                profilePublicId = upload.PublicId;
+            }
+
+            double? rating = await _googleRatingService.GetRatingAsync(request.BusinessName, request.Address, cancellationToken);
+
+            var profile = new PetBusinessProfile
+            {
+                UserId = user.Id,
+                BusinessName = request.BusinessName,
+                OwnerName = request.OwnerName,
+                BusinessStartDate = request.BusinessStartDate,
+                Address = request.Address,
+                PhoneNumber = request.PhoneNumber,
+                Email = request.Email,
+                EINorSSN = request.EINorSSN,
+                NumberOfEmployees = request.NumberOfEmployees,
+                BusinessType = request.BusinessType,
+                GoogleRating = rating,
+                GoogleRatingLink = request.GoogleRatingLink,
+                BannerImagePath = bannerUrl,
+                ProfileImagePath = profileUrl
+            };
+
+            _dbContext.PetBusinessProfiles.Add(profile);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await tx.CommitAsync(cancellationToken);
+
+            return ApiResponse<long>.Success(profile.Id, "Business profile created!", 201);
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync(cancellationToken);
+            if (!string.IsNullOrEmpty(bannerPublicId))
+            {
+                try { await _imageService.DeleteImageAsync(bannerPublicId); } catch { }
+            }
+            if (!string.IsNullOrEmpty(profilePublicId))
+            {
+                try { await _imageService.DeleteImageAsync(profilePublicId); } catch { }
+            }
+            return ApiResponse<long>.Fail("Registration failed: " + ex.Message, 500);
+        }
+    }
+}

--- a/Application/Businesses/Commands/UpdatePetBusinessProfileCommand.cs
+++ b/Application/Businesses/Commands/UpdatePetBusinessProfileCommand.cs
@@ -1,0 +1,22 @@
+using Application.Common.Models;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace Application.Businesses.Commands;
+
+public class UpdatePetBusinessProfileCommand : IRequest<ApiResponse<long>>
+{
+    public string IdentityId { get; set; }
+    public string BusinessName { get; set; }
+    public string? OwnerName { get; set; }
+    public DateTime? BusinessStartDate { get; set; }
+    public string Address { get; set; }
+    public string PhoneNumber { get; set; }
+    public string Email { get; set; }
+    public string EINorSSN { get; set; }
+    public int? NumberOfEmployees { get; set; }
+    public string? BusinessType { get; set; }
+    public string? GoogleRatingLink { get; set; }
+    public IFormFile? BannerImage { get; set; }
+    public IFormFile? ProfileImage { get; set; }
+}

--- a/Application/Businesses/Commands/UpdatePetBusinessProfileCommandHandler.cs
+++ b/Application/Businesses/Commands/UpdatePetBusinessProfileCommandHandler.cs
@@ -1,0 +1,95 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+
+namespace Application.Businesses.Commands;
+
+public class UpdatePetBusinessProfileCommandHandler : IRequestHandler<UpdatePetBusinessProfileCommand, ApiResponse<long>>
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly IImageService _imageService;
+    private readonly IGoogleRatingService _googleRatingService;
+
+    public UpdatePetBusinessProfileCommandHandler(ApplicationDbContext dbContext, IImageService imageService, IGoogleRatingService googleRatingService)
+    {
+        _dbContext = dbContext;
+        _imageService = imageService;
+        _googleRatingService = googleRatingService;
+    }
+
+    public async Task<ApiResponse<long>> Handle(UpdatePetBusinessProfileCommand request, CancellationToken cancellationToken)
+    {
+        string? bannerPublicId = null;
+        string? profilePublicId = null;
+        using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            var user = await _dbContext.Users
+                .Include(u => u.PetBusinessProfile)
+                .FirstOrDefaultAsync(u => u.IdentityId == request.IdentityId, cancellationToken);
+            if (user == null)
+                return ApiResponse<long>.Fail("User not found.", 404);
+
+            var profile = user.PetBusinessProfile;
+            if (profile == null)
+            {
+                profile = new PetBusinessProfile { UserId = user.Id };
+                _dbContext.PetBusinessProfiles.Add(profile);
+            }
+
+            string? bannerUrl = profile.BannerImagePath;
+            if (request.BannerImage != null)
+            {
+                var upload = await _imageService.UploadImageAsync(request.BannerImage);
+                bannerUrl = upload.Url;
+                bannerPublicId = upload.PublicId;
+            }
+
+            string? profileUrl = profile.ProfileImagePath;
+            if (request.ProfileImage != null)
+            {
+                var upload = await _imageService.UploadImageAsync(request.ProfileImage);
+                profileUrl = upload.Url;
+                profilePublicId = upload.PublicId;
+            }
+
+            double? rating = await _googleRatingService.GetRatingAsync(request.BusinessName, request.Address, cancellationToken);
+
+            profile.BusinessName = request.BusinessName;
+            profile.OwnerName = request.OwnerName;
+            profile.BusinessStartDate = request.BusinessStartDate;
+            profile.Address = request.Address;
+            profile.PhoneNumber = request.PhoneNumber;
+            profile.Email = request.Email;
+            profile.EINorSSN = request.EINorSSN;
+            profile.NumberOfEmployees = request.NumberOfEmployees;
+            profile.BusinessType = request.BusinessType;
+            profile.GoogleRating = rating;
+            profile.GoogleRatingLink = request.GoogleRatingLink;
+            profile.BannerImagePath = bannerUrl;
+            profile.ProfileImagePath = profileUrl;
+            profile.UpdatedAt = DateTime.Now;
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            await tx.CommitAsync(cancellationToken);
+
+            return ApiResponse<long>.Success(profile.Id, "Business profile updated!", 200);
+        }
+        catch (Exception ex)
+        {
+            await tx.RollbackAsync(cancellationToken);
+            if (!string.IsNullOrEmpty(bannerPublicId))
+            {
+                try { await _imageService.DeleteImageAsync(bannerPublicId); } catch { }
+            }
+            if (!string.IsNullOrEmpty(profilePublicId))
+            {
+                try { await _imageService.DeleteImageAsync(profilePublicId); } catch { }
+            }
+            return ApiResponse<long>.Fail("Update failed: " + ex.Message, 500);
+        }
+    }
+}

--- a/Application/Businesses/Queries/GetPetBusinessProfileQuery.cs
+++ b/Application/Businesses/Queries/GetPetBusinessProfileQuery.cs
@@ -1,0 +1,67 @@
+using Application.Common.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Persistence;
+
+namespace Application.Businesses.Queries;
+
+public class GetPetBusinessProfileQuery : IRequest<ApiResponse<PetBusinessProfileDto>>
+{
+    public string IdentityId { get; set; }
+}
+
+public class PetBusinessProfileDto
+{
+    public string BusinessName { get; set; }
+    public string? OwnerName { get; set; }
+    public DateTime? BusinessStartDate { get; set; }
+    public string Address { get; set; }
+    public string PhoneNumber { get; set; }
+    public string Email { get; set; }
+    public string EINorSSN { get; set; }
+    public int? NumberOfEmployees { get; set; }
+    public string? BusinessType { get; set; }
+    public double? GoogleRating { get; set; }
+    public string? GoogleRatingLink { get; set; }
+    public string? BannerImagePath { get; set; }
+    public string? ProfileImagePath { get; set; }
+}
+
+public class GetPetBusinessProfileQueryHandler : IRequestHandler<GetPetBusinessProfileQuery, ApiResponse<PetBusinessProfileDto>>
+{
+    private readonly ApplicationDbContext _dbContext;
+
+    public GetPetBusinessProfileQueryHandler(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<ApiResponse<PetBusinessProfileDto>> Handle(GetPetBusinessProfileQuery request, CancellationToken cancellationToken)
+    {
+        var user = await _dbContext.Users
+            .Include(u => u.PetBusinessProfile)
+            .FirstOrDefaultAsync(u => u.IdentityId == request.IdentityId, cancellationToken);
+        if (user == null || user.PetBusinessProfile == null)
+            return ApiResponse<PetBusinessProfileDto>.Fail("Business profile not found.", 404);
+
+        var profile = user.PetBusinessProfile;
+        var dto = new PetBusinessProfileDto
+        {
+            BusinessName = profile.BusinessName,
+            OwnerName = profile.OwnerName,
+            BusinessStartDate = profile.BusinessStartDate,
+            Address = profile.Address,
+            PhoneNumber = profile.PhoneNumber,
+            Email = profile.Email,
+            EINorSSN = profile.EINorSSN,
+            NumberOfEmployees = profile.NumberOfEmployees,
+            BusinessType = profile.BusinessType,
+            GoogleRating = profile.GoogleRating,
+            GoogleRatingLink = profile.GoogleRatingLink,
+            BannerImagePath = profile.BannerImagePath,
+            ProfileImagePath = profile.ProfileImagePath
+        };
+
+        return ApiResponse<PetBusinessProfileDto>.Success(dto);
+    }
+}

--- a/Application/Common/Interfaces/IGoogleRatingService.cs
+++ b/Application/Common/Interfaces/IGoogleRatingService.cs
@@ -1,0 +1,6 @@
+namespace Application.Common.Interfaces;
+
+public interface IGoogleRatingService
+{
+    Task<double?> GetRatingAsync(string businessName, string address, CancellationToken cancellationToken = default);
+}

--- a/Application/Users/Queries/GetUserProfileQuery.cs
+++ b/Application/Users/Queries/GetUserProfileQuery.cs
@@ -35,8 +35,18 @@ public class PetOwnerProfileDto
 public class PetBusinessProfileDto
 {
     public string BusinessName { get; set; }
+    public string? OwnerName { get; set; }
+    public DateTime? BusinessStartDate { get; set; }
     public string Address { get; set; }
-    public string WebsiteUrl { get; set; }
+    public string PhoneNumber { get; set; }
+    public string Email { get; set; }
+    public string EINorSSN { get; set; }
+    public int? NumberOfEmployees { get; set; }
+    public string? BusinessType { get; set; }
+    public double? GoogleRating { get; set; }
+    public string? GoogleRatingLink { get; set; }
+    public string? BannerImagePath { get; set; }
+    public string? ProfileImagePath { get; set; }
 }
 
 public class ContentCreatorProfileDto
@@ -85,8 +95,18 @@ public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, A
             BusinessProfile = user.PetBusinessProfile == null ? null : new PetBusinessProfileDto
             {
                 BusinessName = user.PetBusinessProfile.BusinessName,
+                OwnerName = user.PetBusinessProfile.OwnerName,
+                BusinessStartDate = user.PetBusinessProfile.BusinessStartDate,
                 Address = user.PetBusinessProfile.Address,
-                WebsiteUrl = user.PetBusinessProfile.WebsiteUrl
+                PhoneNumber = user.PetBusinessProfile.PhoneNumber,
+                Email = user.PetBusinessProfile.Email,
+                EINorSSN = user.PetBusinessProfile.EINorSSN,
+                NumberOfEmployees = user.PetBusinessProfile.NumberOfEmployees,
+                BusinessType = user.PetBusinessProfile.BusinessType,
+                GoogleRating = user.PetBusinessProfile.GoogleRating,
+                GoogleRatingLink = user.PetBusinessProfile.GoogleRatingLink,
+                BannerImagePath = user.PetBusinessProfile.BannerImagePath,
+                ProfileImagePath = user.PetBusinessProfile.ProfileImagePath
             },
             CreatorProfile = user.ContentCreatorProfile == null ? null : new ContentCreatorProfileDto
             {
@@ -98,4 +118,3 @@ public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, A
         return ApiResponse<UserProfileDto>.Success(dto);
     }
 }
-

--- a/Domain/Entities/PetBusinessProfile.cs
+++ b/Domain/Entities/PetBusinessProfile.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Domain.Entities;
 
@@ -9,9 +9,18 @@ public class PetBusinessProfile
     public long UserId { get; set; }
 
     public string BusinessName { get; set; }
+    public string? OwnerName { get; set; }
+    public DateTime? BusinessStartDate { get; set; }
     public string Address { get; set; }
-    public string WebsiteUrl { get; set; }
-
+    public string PhoneNumber { get; set; }
+    public string Email { get; set; }
+    public string EINorSSN { get; set; }
+    public int? NumberOfEmployees { get; set; }
+    public string? BusinessType { get; set; }
+    public double? GoogleRating { get; set; }
+    public string? GoogleRatingLink { get; set; }
+    public string? BannerImagePath { get; set; }
+    public string? ProfileImagePath { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.Now;
     public DateTime UpdatedAt { get; set; } = DateTime.Now;

--- a/Infrastructure/DependencyInjection.cs
+++ b/Infrastructure/DependencyInjection.cs
@@ -1,4 +1,3 @@
-﻿
 using Application.Common.Interfaces;
 using Infrastructure.Services;
 using Microsoft.Extensions.Configuration;
@@ -12,6 +11,7 @@ public static class DependencyInjection
     {
         services.AddSingleton<IImageService, ImageService>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
+        services.AddHttpClient<IGoogleRatingService, GoogleRatingService>();
 
         return services;
     }

--- a/Infrastructure/Services/GoogleRatingService.cs
+++ b/Infrastructure/Services/GoogleRatingService.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using Application.Common.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace Infrastructure.Services;
+
+public class GoogleRatingService : IGoogleRatingService
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+
+    public GoogleRatingService(HttpClient httpClient, IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _apiKey = configuration["GoogleApiKey"];
+    }
+
+    public async Task<double?> GetRatingAsync(string businessName, string address, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(_apiKey))
+            return null;
+
+        var query = $"{businessName} {address}";
+        var url = $"https://maps.googleapis.com/maps/api/place/textsearch/json?query={Uri.EscapeDataString(query)}&key={_apiKey}";
+
+        var response = await _httpClient.GetAsync(url, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        try
+        {
+            using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var json = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+            var results = json.RootElement.GetProperty("results");
+            if (results.GetArrayLength() > 0)
+            {
+                var first = results[0];
+                if (first.TryGetProperty("rating", out var ratingElem) && ratingElem.TryGetDouble(out var rating))
+                {
+                    return rating;
+                }
+            }
+        }
+        catch
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/PetSocialAPI/Controllers/BusinessController.cs
+++ b/PetSocialAPI/Controllers/BusinessController.cs
@@ -1,0 +1,51 @@
+using Application.Businesses.Commands;
+using Application.Businesses.Queries;
+using Application.Common.Models;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PetSocialAPI.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class BusinessController(IMediator mediator) : ControllerBase
+{
+    private readonly IMediator _mediator = mediator;
+
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromForm] RegisterPetBusinessCommand command)
+    {
+        var identityId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        if (string.IsNullOrEmpty(identityId))
+            return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
+        command.IdentityId = identityId;
+        var result = await _mediator.Send(command);
+        return StatusCode(result.StatusCode, result);
+    }
+
+    [HttpPut]
+    public async Task<IActionResult> Update([FromForm] UpdatePetBusinessProfileCommand command)
+    {
+        var identityId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        if (string.IsNullOrEmpty(identityId))
+            return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
+        command.IdentityId = identityId;
+        var result = await _mediator.Send(command);
+        return StatusCode(result.StatusCode, result);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> Get()
+    {
+        var identityId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+            ?? User.FindFirst("sub")?.Value;
+        if (string.IsNullOrEmpty(identityId))
+            return Unauthorized(ApiResponse<string>.Fail("Invalid token.", 401));
+        var result = await _mediator.Send(new GetPetBusinessProfileQuery { IdentityId = identityId });
+        return StatusCode(result.StatusCode, result);
+    }
+}


### PR DESCRIPTION
## Summary
- expand PetBusinessProfile with business details, images, and Google rating
- add commands, queries, and API controller to register, update, and fetch business profiles
- integrate Google rating service and configure dependency injection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ba97f6900c832bb96b91f65f066b1b