### PR TITLE
Add pet business profile entity and migration

### DIFF
--- a/Domain/Entities/PetBusinessProfile.cs
+++ b/Domain/Entities/PetBusinessProfile.cs
@@ -1,0 +1,25 @@
+namespace Domain.Entities;
+
+public class PetBusinessProfile
+{
+    public long Id { get; set; }
+    public long UserId { get; set; }
+    public string BusinessName { get; set; }
+    public string? OwnerName { get; set; }
+    public DateTime? BusinessStartDate { get; set; }
+    public string Address { get; set; }
+    public string PhoneNumber { get; set; }
+    public string Email { get; set; }
+    public string SecurityNumber { get; set; }
+    public string SecurityType { get; set; }
+    public int? NumberOfEmployees { get; set; }
+    public string? BusinessType { get; set; }
+    public double? GoogleRating { get; set; }
+    public string? GoogleRatingLink { get; set; }
+    public string? BannerImagePath { get; set; }
+    public string? ProfileImagePath { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    public User? User { get; set; }
+}

--- a/Persistence/ApplicationDbContext.cs
+++ b/Persistence/ApplicationDbContext.cs
@@ -23,6 +23,7 @@ public class ApplicationDbContext : IdentityDbContext
     public DbSet<PetStoryView> PetStoryViews { get; set; }
     public DbSet<PetStoryLike> PetStoryLikes { get; set; }
     public DbSet<PetStoryComment> PetStoryComments { get; set; }
+    public DbSet<PetBusinessProfile> PetBusinessProfiles { get; set; }
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/Persistence/Migrations/20250724183000_AddPetBusinessProfileTable.cs
+++ b/Persistence/Migrations/20250724183000_AddPetBusinessProfileTable.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPetBusinessProfileTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PetBusinessProfile",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<long>(type: "bigint", nullable: false),
+                    BusinessName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    OwnerName = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    BusinessStartDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    Address = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    PhoneNumber = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    SecurityNumber = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false, defaultValue: ""),
+                    SecurityType = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false, defaultValue: ""),
+                    NumberOfEmployees = table.Column<int>(type: "int", nullable: true),
+                    BusinessType = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    GoogleRating = table.Column<double>(type: "float", nullable: true),
+                    GoogleRatingLink = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    BannerImagePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    ProfileImagePath = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "SYSUTCDATETIME()"),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "SYSUTCDATETIME()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PetBusinessProfile", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PetBusinessProfile_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_PetBusinessProfile_UserId",
+                table: "PetBusinessProfile",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PetBusinessProfile");
+        }
+    }
+}

--- a/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -68,6 +68,100 @@ namespace Persistence.Migrations
                     b.ToTable("Users");
                 });
 
+            modelBuilder.Entity("Domain.Entities.PetBusinessProfile", b =>
+                {
+                    b.Property<long>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bigint");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+
+                    b.Property<string>("Address")
+                        .IsRequired()
+                        .HasMaxLength(500)
+                        .HasColumnType("nvarchar(500)");
+
+                    b.Property<string>("BannerImagePath")
+                        .HasMaxLength(1024)
+                        .HasColumnType("nvarchar(1024)");
+
+                    b.Property<DateTime?>("BusinessStartDate")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("BusinessName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("BusinessType")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("SYSUTCDATETIME()");
+
+                    b.Property<string>("Email")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b.Property<double?>("GoogleRating")
+                        .HasColumnType("float");
+
+                    b.Property<string>("GoogleRatingLink")
+                        .HasMaxLength(2048)
+                        .HasColumnType("nvarchar(2048)");
+
+                    b.Property<int?>("NumberOfEmployees")
+                        .HasColumnType("int");
+
+                    b.Property<string>("OwnerName")
+                        .HasMaxLength(100)
+                        .HasColumnType("nvarchar(100)");
+
+                    b.Property<string>("PhoneNumber")
+                        .IsRequired()
+                        .HasMaxLength(30)
+                        .HasColumnType("nvarchar(30)");
+
+                    b.Property<string>("ProfileImagePath")
+                        .HasMaxLength(1024)
+                        .HasColumnType("nvarchar(1024)");
+
+                    b.Property<string>("SecurityNumber")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)")
+                        .HasDefaultValue("");
+
+                    b.Property<string>("SecurityType")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)")
+                        .HasDefaultValue("");
+
+                    b.Property<long>("UserId")
+                        .HasColumnType("bigint");
+
+                    b.Property<DateTime>("UpdatedAt")
+                        .HasColumnType("datetime2")
+                        .HasDefaultValueSql("SYSUTCDATETIME()");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId")
+                        .IsUnique();
+
+                    b.ToTable("PetBusinessProfile");
+
+                    b.HasOne("Domain.Entities.User", null)
+                        .WithOne()
+                        .HasForeignKey("Domain.Entities.PetBusinessProfile", "UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
                     b.Property<string>("Id")


### PR DESCRIPTION
## Summary
- add PetBusinessProfile entity and database set
- create migration and snapshot entries for PetBusinessProfile table

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` (failed: Unable to locate package)
- `apt-get install -y dotnet-sdk-8.0` (failed: Unable to locate package)
- `dotnet --version` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ba9dbc2e34832bb2ad84860a8d2074